### PR TITLE
Build the server in docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.git/
+dist/
+coverage/
+node_modules/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,32 @@
+FROM node:alpine as builder
+
+WORKDIR /build
+
+# Create the build environment (will not change often, will be cached in docker)
+COPY package.json ./
+RUN yarn
+
+COPY src src
+COPY test test
+COPY .babelrc jest.conf.js tsconfig.json webpack.config.js yarn.lock ./
+RUN yarn build:server
+
+
 FROM node:alpine
 
-WORKDIR /usr/src/app
-COPY package.json .
-COPY bin bin
-COPY dist dist
+WORKDIR /srv
 
+# Create the run environment (will not change often, will be cached in docker)
+COPY package.json ./
 ENV NODE_ENV production
-RUN npm install
+RUN yarn install
+
+COPY bin bin
+COPY --from=builder /build/dist dist
 
 ARG CONFIG_FOLDER
 RUN test -n "$CONFIG_FOLDER"
 COPY ${CONFIG_FOLDER} config
-
-RUN echo ${CONFIG_FOLDER}
-RUN ls ./config
-RUN ls
 
 EXPOSE 8080
 CMD [ "node", "./bin/spacegun-server", "-c", "./config/config.yml" ]


### PR DESCRIPTION
This also splits and reorders the build to improve the caching of
intermediate images.